### PR TITLE
Memory leak

### DIFF
--- a/src/ru/greeneyes/project/pomidoro/toolkitwindow/PomodoroToolWindows.java
+++ b/src/ru/greeneyes/project/pomidoro/toolkitwindow/PomodoroToolWindows.java
@@ -28,8 +28,6 @@ import ru.greeneyes.project.pomidoro.model.ChangeListener;
 import ru.greeneyes.project.pomidoro.model.Settings;
 
 import javax.swing.*;
-import java.util.HashSet;
-import java.util.Set;
 
 /**
  * @author ivanalx
@@ -39,7 +37,6 @@ public class PomodoroToolWindows implements ChangeListener {
 	public static final String TOOL_WINDOW_ID = "Pomodoro";
 
 	private static final ImageIcon pomodoroIcon = new ImageIcon(PomodoroToolWindows.class.getResource("/resources/pomodoro-icon.png"));
-	private final Set<Project> hasRegisteredWindow = new HashSet<Project>();
 
 	public PomodoroToolWindows() {
 		ProjectManager.getInstance().addProjectManagerListener(new ProjectManagerListener() {
@@ -77,13 +74,14 @@ public class PomodoroToolWindows implements ChangeListener {
 	}
 
 	public void registerWindowFor(Project project) {
-		if (hasRegisteredWindow.contains(project)) return;
-		hasRegisteredWindow.add(project);
+		ToolWindowManager toolWindowManager = ToolWindowManager.getInstance(project);
+		if (toolWindowManager.getToolWindow(TOOL_WINDOW_ID) != null) {
+			return;
+		}
 
 		PomodoroComponent pomodoroComponent = ApplicationManager.getApplication().getComponent(PomodoroComponent.class);
 		PomodoroPresenter presenter = new PomodoroPresenter(pomodoroComponent.getModel());
 
-		ToolWindowManager toolWindowManager = ToolWindowManager.getInstance(project);
 		ToolWindow myToolWindow = toolWindowManager.registerToolWindow(TOOL_WINDOW_ID, false, ToolWindowAnchor.BOTTOM);
 		myToolWindow.setIcon(pomodoroIcon);
 		ContentFactory contentFactory = ContentFactory.SERVICE.getInstance();
@@ -92,9 +90,9 @@ public class PomodoroToolWindows implements ChangeListener {
 	}
 
 	public void unregisterWindowFrom(Project project) {
-		if (hasRegisteredWindow.contains(project)) {
-			hasRegisteredWindow.remove(project);
-			ToolWindowManager.getInstance(project).unregisterToolWindow(TOOL_WINDOW_ID);
+		final ToolWindowManager toolWindowManager = ToolWindowManager.getInstance(project);
+		if (toolWindowManager.getToolWindow(TOOL_WINDOW_ID) != null) {
+			toolWindowManager.unregisterToolWindow(TOOL_WINDOW_ID);
 		}
 	}
 }


### PR DESCRIPTION
Earlier today I noticed that your pomodoro-tm plugin contained a memory leak. The plugin was hanging on to instances of the com.intellij.openapi.project.Project interface after the project was closed. This causes many megabytes of project data to remain in memory instead of being garbage collected. After opening a few projects the effect is very noticeable. 

The leak was easy to fix, and I have done so for my own personal use. Perhaps you will find it useful also. 

In general for IntelliJ IDEA plugins it is a bad idea to hang on to instances of Project except as a field in implementations of com.intellij.openapi.components.ProjectComponent.

Thanks for the plugin,
Bas
