### PR TITLE
Add statistics

### DIFF
--- a/resources/messages.properties
+++ b/resources/messages.properties
@@ -1,7 +1,7 @@
 notification.text=Pomodoro is finished!<br/>Please take a break.
 notification.pomodoro_start=New pomodoro has been started!
 
-statuspanel.tooltip=Click to {0}. Pomodoros done: {1}
+statuspanel.tooltip=Click to {0}. Pomodoros done: today {1} ({2} incomplete), past week {3} ({4} incomplete), past 28 days {5} ({6} incomplete)
 statuspanel.widget_tooltip=Click to {0}. Alt-click for more actions.
 statuspanel.start=start pomodoro
 statuspanel.stop=stop pomodoro

--- a/src/pomodoro/model/PomodoroModel.kt
+++ b/src/pomodoro/model/PomodoroModel.kt
@@ -46,6 +46,7 @@ class PomodoroModel(originalSettings: Settings, val state: PomodoroState) {
                 if (pomodorosTillLongBreak == 0) {
                     pomodorosTillLongBreak = settings.longBreakFrequency
                 }
+                history.add(PomodoroSnapshot.failed(startTime = startTime, endTime = time))
             }
             Break -> {
                 mode = Stop
@@ -67,6 +68,7 @@ class PomodoroModel(originalSettings: Settings, val state: PomodoroState) {
                 if (time >= startTime + progressMax) {
                     mode = Break
                     settings = updatedSettings
+                    history.add(PomodoroSnapshot.completed(startTime = startTime, endTime = time))
                     startTime = time
                     progress = progressSince(time)
                     pomodorosAmount++

--- a/src/pomodoro/model/PomodoroSnapshot.kt
+++ b/src/pomodoro/model/PomodoroSnapshot.kt
@@ -1,0 +1,59 @@
+package pomodoro.model
+
+import pomodoro.model.PomodoroSnapshot.Period.*
+import pomodoro.model.PomodoroSnapshot.Status.Completed
+import pomodoro.model.PomodoroSnapshot.Status.Failed
+import pomodoro.model.time.Duration
+import pomodoro.model.time.Time
+import pomodoro.model.time.days
+
+data class PomodoroSnapshot(val startTime: Time = Time.zero, val endTime: Time = Time.zero, val status: Status = Completed) {
+    enum class Status {
+        Completed,
+        Failed
+    }
+    enum class Period(val duration: Duration) {
+        Today(1.days),
+        PastWeek(7.days),
+        Past28Days(28.days),
+        OutOfRange(Duration.zero)
+    }
+
+    private fun isInPeriod(referenceTime: Time, period: Period): Boolean {
+        val startOfDay = referenceTime.atStartOfDay()
+        return when (period) {
+            Today -> this.startTime in startOfDay..referenceTime
+            PastWeek -> this.startTime in startOfDay - PastWeek.duration .. referenceTime
+            Past28Days -> this.startTime in startOfDay - Past28Days.duration .. referenceTime
+            OutOfRange -> false
+        }
+    }
+
+    companion object {
+
+        fun completed(startTime: Time, endTime: Time) = PomodoroSnapshot(startTime, endTime, Completed)
+
+        fun failed(startTime: Time, endTime: Time) = PomodoroSnapshot(startTime, endTime, Failed)
+
+        fun statisticsAt(time: Time, history: List<PomodoroSnapshot>): PomodoroStatistics {
+            return PomodoroStatistics(today = pomodoroCountsInPeriod(history, time, Today),
+                    week = pomodoroCountsInPeriod(history, time, PastWeek),
+                    month = pomodoroCountsInPeriod(history, time, Past28Days))
+        }
+
+        private fun pomodoroCountsInPeriod(history: List<PomodoroSnapshot>, time: Time, period: Period): PomodoroCounts {
+            val countsByStatus = history.filter { s -> s.isInPeriod(time, period) }.groupingBy { s -> s.status }.eachCount()
+            return PomodoroCounts.from(countsByStatus)
+        }
+    }
+}
+
+data class PomodoroStatistics(val today: PomodoroCounts, val week: PomodoroCounts, val month: PomodoroCounts)
+
+data class PomodoroCounts(val completed: Int = 0, val failed: Int = 0) {
+    companion object {
+        fun from(counts: Map<PomodoroSnapshot.Status, Int>) = PomodoroCounts(
+                completed = counts.getOrDefault(Completed, 0),
+                failed = counts.getOrDefault(Failed, 0))
+    }
+}

--- a/src/pomodoro/model/PomodoroState.kt
+++ b/src/pomodoro/model/PomodoroState.kt
@@ -23,7 +23,8 @@ data class PomodoroState(
     @OptionTag(nameAttribute = "lastUpdateTime", converter = TimeConverter::class) var lastUpdateTime: Time = Time.zero,
     @OptionTag(nameAttribute = "pomodorosAmount") var pomodorosAmount: Int = 0,
     @Transient var progress: Duration = Duration.zero,
-    var pomodorosTillLongBreak: Int = Settings.defaultLongBreakFrequency
+    var pomodorosTillLongBreak: Int = Settings.defaultLongBreakFrequency,
+    val history: MutableList<PomodoroSnapshot> = mutableListOf()
 ) : PersistentStateComponent<PomodoroState> {
 
     override fun getState() = this

--- a/src/pomodoro/model/time/Duration.kt
+++ b/src/pomodoro/model/time/Duration.kt
@@ -25,8 +25,13 @@ data class Duration(internal val delegate: JavaDuration = JavaDuration.ZERO) : C
         val zero = Duration(0)
 
         fun between(start: Time, end: Time) = Duration(JavaDuration.between(start.instant, end.instant))
+
+        fun ofDays(days: Long) = Duration(JavaDuration.ofDays(days))
     }
 }
 
 val Number.minutes: Duration
     get() = Duration(minutes = toInt())
+
+val Number.days: Duration
+    get() = Duration.ofDays(days = toLong())

--- a/src/pomodoro/model/time/Time.kt
+++ b/src/pomodoro/model/time/Time.kt
@@ -1,6 +1,7 @@
 package pomodoro.model.time
 
 import java.time.Instant
+import java.time.temporal.ChronoUnit
 
 data class Time(internal val instant: Instant = Instant.EPOCH) : Comparable<Time> {
     val epochMilli: Long = instant.toEpochMilli()
@@ -10,6 +11,10 @@ data class Time(internal val instant: Instant = Instant.EPOCH) : Comparable<Time
     override fun compareTo(other: Time) = instant.compareTo(other.instant)
 
     operator fun plus(duration: Duration) = Time(instant + duration.delegate)
+
+    operator fun minus(duration: Duration) = Time(instant - duration.delegate)
+
+    fun atStartOfDay() = Time(instant.truncatedTo(ChronoUnit.DAYS))
 
     companion object {
         val zero = Time(Instant.EPOCH)

--- a/src/pomodoro/widget/PomodoroWidget.kt
+++ b/src/pomodoro/widget/PomodoroWidget.kt
@@ -19,6 +19,7 @@ import pomodoro.ResetPomodorosCounter
 import pomodoro.StartOrStopPomodoro
 import pomodoro.UIBundle
 import pomodoro.model.PomodoroModel
+import pomodoro.model.PomodoroSnapshot
 import pomodoro.model.PomodoroState
 import pomodoro.model.PomodoroState.Mode.*
 import pomodoro.model.Settings
@@ -73,7 +74,9 @@ class PomodoroWidget : CustomStatusBarWidget, StatusBarWidget.Multiframe, Settin
             }
 
             override fun mouseEntered(e: MouseEvent?) {
-                statusBar.info = UIBundle.message("statuspanel.tooltip", nextActionName(model), model.state.pomodorosAmount)
+                val (today, week, month) = PomodoroSnapshot.statisticsAt(Time.now(), model.state.history)
+                statusBar.info = UIBundle.message("statuspanel.tooltip", nextActionName(model),
+                        today.completed, today.failed, week.completed, week.failed, month.completed, month.failed)
             }
 
             override fun mouseExited(e: MouseEvent?) {


### PR DESCRIPTION
Greetings Dmitry,

I've been enjoying your simple and very useful Pomodoro plugin for a while, so thanks for that :-)

In this pull request I'm submitting a proposal for some simple statistics for past day, week, month for issue #9. It displays a message like the following in the status bar when the Pomodoro timer is hovered:

"Pomodoros done: today 4 (1 incomplete), past week 18 (3 incomplete), past 28 days 70 (9 incomplete)"

It's my first Kotlin project, I've tried to follow the existing style, but I'd be glad of any suggestions to improve the design. If it looks interesting then I can tune it with your feedback. One thing I think it could use is some kind of cleanup of old statistics, e.g. automatically when older than one month or when the Pomodoros counter is reset.

Regards,
Gary